### PR TITLE
Place the past events in reverse-chronological order

### DIFF
--- a/src/pages/events.tsx
+++ b/src/pages/events.tsx
@@ -268,9 +268,8 @@ const EventsPage = () => {
             {events
               .sort((a, b) => a.time.milliseconds() - b.time.millisecond())
               .filter((event) => event.time < moment())
-              .map((event) => (
-                <EventCard {...event} />
-              ))}
+              .map((event) => <EventCard {...event} />)
+              .reverse()}
           </EventsContainer>
         </>
       )}


### PR DESCRIPTION
Currently the past events on the website are displayed in chronological order. However, it makes more sense for the most recent event to be at the top. This PR makes that change.